### PR TITLE
Bump import-cost & until-build version constraints

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -9,6 +9,6 @@
   "author": "Dennis Ushakov",
   "license": "Apache-2.0",
   "dependencies": {
-    "import-cost": "1.3.1"
+    "import-cost": "1.4.0"
   }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
     <name>Import Cost</name>
     <id>ImportCost</id>
     <version>1.0.4</version>
-    <idea-version since-build="172.3317" until-build="181.*"/>
+    <idea-version since-build="172.3317" until-build="182.*"/>
     <vendor email="dennis.ushakov@jetbrains.com" url="https://github.com/denofevil/import-cost">Dennis Ushakov, Andrey Starovoyt</vendor>
     <description><![CDATA[
         This extension will display inline in the editor the size of the imported package.


### PR DESCRIPTION
- Bumped `import-cost` package to `v1.4.0`
- Bumped `until-build` to `182.*` to support latest releases

I manually tested both changes (copied node_modules, updated plugin.xml & manually installed) so I think it should be fine.

Please note that I haven't tried to build from sources with these changes.

Haven't seen any issues with the latest PhpStorm
```
PhpStorm 2018.2 EAP
Build #PS-182.2949.27, built on June 6, 2018
PhpStorm EAP User
Expiration date: July 6, 2018
JRE: 1.8.0_152-release-1226-b7 amd64
JVM: OpenJDK 64-Bit Server VM by JetBrains s.r.o
Windows 10 10.0
```