### PR TITLE
add config to getSize()

### DIFF
--- a/javascript/index.js
+++ b/javascript/index.js
@@ -3,7 +3,8 @@ const {getSize} = require('import-cost/dist/src/packageInfo');
 class ImportCostPlugin {
     onMessage(p, messageWriter) {
         const {seq, arguments: packageInfo} = JSON.parse(p);
-        getSize(packageInfo).then((pkg) => {
+        const config = {maxCallTime: Infinity, concurrent: true};
+        getSize(packageInfo, config).then((pkg) => {
             messageWriter.write(JSON.stringify({request_seq: seq, package: pkg}))
         }).catch((e) => {
             messageWriter.write(JSON.stringify({request_seq: seq, error: e}))


### PR DESCRIPTION
Hi @denofevil,

We recently did some changes to the import-cost package,
and since we don't consider `getSize()` to be public API, we changed its signature a bit.

Please see this pull request as a general suggestion. With this config, the behavior should stay the same. But, as you can probably guess, changing `maxCallTime` is helpful 😄 
